### PR TITLE
Add GitHub Actions workflow for automated npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      
+      - name: Run tests
+        run: yarn test:all
+      
+      - name: Build
+        run: yarn build
+      
+      - name: Publish to npm
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to Captan will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-08-17
+
+### Added
+- Initial release of Captan CLI cap table management tool
+- Core cap table functionality:
+  - Stakeholder management (persons and entities)
+  - Security classes (Common, Preferred, Option Pool)
+  - Share issuances with certificate tracking
+  - Option grants with vesting schedules (cliff and monthly vesting)
+- SAFE (Simple Agreement for Future Equity) support:
+  - Add SAFEs with cap, discount, and type (pre/post money)
+  - List all outstanding SAFEs
+  - Simulate SAFE conversion at priced rounds
+  - Integration with cap table reporting
+- Entity type support (C-Corp, S-Corp, LLC) with appropriate terminology
+- Interactive wizard mode for company initialization
+- Founder equity issuance at initialization
+- Comprehensive reporting:
+  - Cap table with outstanding and fully diluted calculations
+  - Stakeholder-specific reports
+  - Security class utilization reports
+  - CSV and JSON export capabilities
+- Audit trail for all actions
+- TypeScript with full type safety
+- Comprehensive test suite (188 tests)
+- ESLint and Prettier configuration
+
+### Technical Details
+- Built with TypeScript and ES modules
+- Service-oriented architecture
+- Commander.js for CLI interface
+- Zod for runtime validation
+- Vitest for testing
+- Single JSON file storage (captable.json)
+- Zero database required
+
+[0.1.0]: https://github.com/acossta/captan/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "format": "prettier --write 'src/**/*.{ts,tsx}'",
     "type-check": "tsc --noEmit",
     "validate": "yarn lint:fix && yarn format && yarn type-check",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "release:patch": "npm version patch && git push && git push --tags",
+    "release:minor": "npm version minor && git push && git push --tags",
+    "release:major": "npm version major && git push && git push --tags"
   },
   "dependencies": {
     "@inquirer/prompts": "^7.8.3",


### PR DESCRIPTION
## Summary
- Add automated npm publishing via GitHub Actions
- Trigger on GitHub release creation
- Use NPM_TOKEN for authentication (already configured in repo secrets)

## Changes
- ✅ Create `.github/workflows/release.yml` workflow
- ✅ Add `CHANGELOG.md` with v0.1.0 release notes
- ✅ Add release scripts to package.json for version bumping

## How it works
1. Create a GitHub release (or use `yarn release:*` scripts)
2. Workflow automatically:
   - Runs tests
   - Builds the project
   - Publishes to npm

This eliminates the need for manual OTP entry during npm publish!