### PR TITLE
Add GitHub Actions release workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Open Source Cap Table Management CLI
 
 [![npm version](https://img.shields.io/npm/v/captan.svg?color=blue&logo=npm)](https://www.npmjs.com/package/captan)
 [![Downloads](https://img.shields.io/npm/dm/captan.svg?color=green)](https://www.npmjs.com/package/captan)
+[![Release to npm](https://github.com/acossta/captan/actions/workflows/release.yml/badge.svg)](https://github.com/acossta/captan/actions/workflows/release.yml)
 [![GitHub stars](https://img.shields.io/github/stars/acossta/captan?style=social)](https://github.com/acossta/captan)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 


### PR DESCRIPTION
Add the GitHub Actions release workflow status badge to README to show build status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Documentation
  - Added a “Release to npm” badge/link to the README, displayed alongside existing npm version and downloads badges.
  - Improves visibility into release pipeline status and provides quick navigation to publishing workflow details.
  - No functional or API changes; no setup or usage changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->