### PR TITLE
docs: add changelog update step to release workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to Captan will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-08-19
+
+### Added
+- Dry-run option (`--dry-run`) for SAFE conversion to preview changes without executing
+- Ownership percentage calculations in SAFE conversion preview
+- Comprehensive unit tests for CLI handlers (coverage improved from 58% to 78%+)
+- Test output folder to .gitignore
+- Ship's wheel emoji (⎈) as new branding logo
+
+### Changed
+- Refactored CLI architecture to extract business logic into testable handlers
+- Improved release workflow documentation with changelog update steps
+
+### Fixed
+- SAFE discount calculation (20% discount now correctly applies as 0.8 multiplier)
+- CLI command structure to match README documentation (`captan enlist stakeholder` instead of `captan stakeholder`)
+- Missing `--action` parameter in log command
+- All CLI commands now properly aligned with README specifications
+
+## [0.2.2] - 2025-08-18
+
+### Fixed
+- CI/CD workflow issues for npm publishing
+- Coverage upload made non-blocking in CI
+
+### Changed
+- Improved release workflow documentation
+
+## [0.2.1] - 2025-08-17
+
+### Fixed
+- npm publishing workflow configuration
+
+## [0.2.0] - 2025-08-17
+
+### Added
+- GitHub Actions CI/CD workflow
+- Automated npm publishing on release
+- Test coverage reporting with Coveralls
+
 ## [0.1.0] - 2025-08-17
 
 ### Added
@@ -41,4 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Single JSON file storage (captable.json)
 - Zero database required
 
+[0.3.0]: https://github.com/acossta/captan/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/acossta/captan/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/acossta/captan/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/acossta/captan/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/acossta/captan/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,28 @@ Before starting a release:
    git push --set-upstream origin release/v0.2.3
    ```
 
-2. **Ensure everything is committed** and pushed to the release branch
+2. **Update CHANGELOG.md**:
+   - Add a new section for the version being released
+   - Follow the [Keep a Changelog](https://keepachangelog.com) format
+   - Include sections: Added, Changed, Fixed, Removed (as applicable)
+   - Example format:
+   ```markdown
+   ## [0.2.3] - 2025-08-20
+   
+   ### Added
+   - Feature descriptions
+   
+   ### Fixed
+   - Bug fix descriptions
+   
+   ### Changed
+   - Changes to existing functionality
+   ```
+   - Commit the changelog: `git add CHANGELOG.md && git commit -m "docs: update CHANGELOG for v0.2.3"`
 
-3. **Bump version and create tag**:
+3. **Ensure everything is committed** and pushed to the release branch
+
+4. **Bump version and create tag**:
    ```bash
    # Choose based on semantic versioning:
    yarn release:patch  # Bug fixes (0.2.2 -> 0.2.3)


### PR DESCRIPTION
## Summary
- Added changelog update requirement to the release workflow
- Documented the v0.3.0 release in CHANGELOG.md
- Improved release process documentation

## What's Changed

### 📚 Documentation
- Added step 2 in CLAUDE.md release workflow to update CHANGELOG.md before version bump
- Documented v0.3.0 release with all features, fixes, and changes
- Added comparison links for all releases (v0.1.0 through v0.3.0)
- Following [Keep a Changelog](https://keepachangelog.com) format

## Why This Change?
Keeping the changelog updated with each release ensures:
1. Users can easily see what changed between versions
2. The project maintains a clear history of changes
3. Release notes are consistent and well-documented

## Test Plan
- [x] Documentation only change - no code impact
- [x] Verified markdown formatting is correct
- [x] All tests still pass (400 tests)
- [x] Release workflow documentation is clear and actionable

**Full Changelog**: https://github.com/acossta/captan/compare/main...update-changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dry-run option to preview SAFE conversion.
  * Ownership percentage shown in SAFE preview.
  * New ship’s wheel (⎈) branding logo.
* **Bug Fixes**
  * Correct SAFE discount calculation (applies 0.8 multiplier).
  * CLI commands aligned with README, including corrected names and required parameters (e.g., log --action).
* **Documentation**
  * Added 0.3.0 changelog with Added/Changed/Fixed sections.
  * Expanded release workflow guidance and release notes template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->