### PR TITLE
fix: Use dynamic version from package.json

### DIFF
--- a/src/cli-version.test.ts
+++ b/src/cli-version.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const cliPath = path.join(__dirname, 'cli.ts');
+
+describe('CLI Version and Help Commands', () => {
+  // Helper to filter out transient noise from command output
+  function stripNoise(output: string): string {
+    return output
+      .split('\n')
+      .filter((line: string) => !/^(npm WARN|npm notice|npx:)/i.test(line))
+      .join('\n')
+      .trim();
+  }
+
+  const runCLI = (args: string): string => {
+    try {
+      const output = execSync(`node --import tsx "${cliPath}" ${args}`, {
+        encoding: 'utf8',
+        cwd: __dirname,
+      });
+      return stripNoise(output);
+    } catch (error: any) {
+      return stripNoise(error.stdout || error.stderr || error.message);
+    }
+  };
+
+  it('should display version with --version flag', () => {
+    const output = runCLI('--version');
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+    );
+    expect(output).toBe(packageJson.version);
+  });
+
+  it('should display version with -V flag', () => {
+    const output = runCLI('-V');
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')
+    );
+    expect(output).toBe(packageJson.version);
+  });
+
+  it('should display help with --help flag', () => {
+    const output = runCLI('--help');
+    expect(output).toContain('Captan');
+    expect(output).toContain('Usage:');
+    expect(output).toContain('Options:');
+    expect(output).toContain('Commands:');
+    expect(output).toContain('--version');
+  });
+
+  it('should display help with -h flag', () => {
+    const output = runCLI('-h');
+    expect(output).toContain('Captan');
+    expect(output).toContain('Usage:');
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,13 +3,17 @@ import { Command } from 'commander';
 import { LOGO, NAME, TAGLINE } from './branding.js';
 import * as handlers from './cli-handlers.js';
 import { exists } from './store.js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const packageJson = require('../package.json');
 
 const program = new Command();
 
 program
   .name('captan')
   .description(`${NAME} — ${TAGLINE}`)
-  .version('0.1.0')
+  .version(packageJson.version)
   .showHelpAfterError('(use --help for usage)')
   .addHelpText('before', LOGO + '\n');
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded version `0.1.0` with dynamic import from package.json
- Ensures `captan --version` and `captan -V` always show the correct version

## Changes
- Import package.json using `createRequire` for ES2020 compatibility
- Add comprehensive test coverage for version and help flags (4 new tests)
- Tests verify version matches package.json

## Test Plan
- [x] Run `npx captan --version` - shows 0.3.1
- [x] Run `npx captan -V` - shows 0.3.1  
- [x] Run `yarn build` - builds successfully
- [x] Run `yarn test:all` - all 521 tests pass
- [x] Added new test file `cli-version.test.ts` with 4 tests

## Why This Matters
Previously, the version was hardcoded as `0.1.0` even though the actual package version is `0.3.1`. This follows CLI best practices used by eslint, prettier, and other major CLIs - maintaining version in a single source of truth (package.json).

**Full Changelog**: https://github.com/acossta/captan/compare/main...fix/dynamic-version-display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI version flags (--version, -V) now consistently display the current package version, preventing mismatches after releases.

* **Tests**
  * Added automated tests validating version output and help content, including program name and key sections (Usage, Options, Commands).

* **Refactor**
  * Version information is resolved dynamically at runtime from the package metadata, removing hard-coded values and reducing maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->