### PR TITLE
Release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to Captan will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2025-08-20
+
+### Added
+- Dynamic version display: `captan --version` and `captan -V` now read version from package.json
+- Comprehensive test coverage for CLI version and help commands
+- Support for decimal par values (e.g., 0.00001) in initialization wizard
+- Min/max constraints on number inputs for better user experience
+- New fractional pool percentage support (e.g., 12.5%)
+
+### Changed
+- Default par value updated from 0.0001 to 0.00001 (industry standard for 10M shares)
+- Default option pool percentage reduced from 20% to 10% (more typical for early-stage startups)
+- Improved pool calculation formula for numerical stability and floating-point precision
+- Enhanced wizard input validation with better error messages
+
+### Fixed
+- "Value must be a multiple of 1" error when entering decimal par values
+- Hardcoded version display (was showing 0.1.0 instead of actual version)
+- Pool calculation edge cases for percentages near 100%
+- NaN handling in founder share parsing
+- Test isolation issues in CLI integration tests
+
 ## [0.3.1] - 2025-08-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "captan",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Captan — Command your ownership. A tiny, hackable CLI cap table tool.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release v0.3.2

This release includes significant improvements to the initialization wizard and CLI functionality.

### ✨ New Features
- Dynamic version display: `captan --version` and `captan -V` now read version from package.json
- Support for decimal par values (e.g., 0.00001) in initialization wizard  
- Min/max constraints on number inputs for better user experience
- Fractional pool percentage support (e.g., 12.5%)

### 🔧 Improvements  
- Default par value updated from 0.0001 to 0.00001 (industry standard for 10M shares)
- Default option pool percentage reduced from 20% to 10% (more typical for early-stage startups)
- Improved pool calculation formula for numerical stability and floating-point precision
- Enhanced wizard input validation with better error messages

### 🐛 Bug Fixes
- Fixed "Value must be a multiple of 1" error when entering decimal par values
- Fixed hardcoded version display (was showing 0.1.0 instead of actual version)
- Fixed pool calculation edge cases for percentages near 100%
- Fixed NaN handling in founder share parsing
- Fixed test isolation issues in CLI integration tests

### 📊 Test Coverage
- Added comprehensive test coverage for CLI version and help commands
- All 521 tests passing
- Maintained high test coverage

**Full Changelog**: https://github.com/acossta/captan/compare/v0.3.1...v0.3.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Dynamic CLI version display.
  * Wizard supports decimal par values and fractional pool percentages (e.g., 12.5%).
  * Numeric inputs now support min/max constraints.

* Changes
  * Default par value set to 0.00001.
  * Default option pool reduced to 10%.
  * Improved pool calculation precision and clearer validation errors.

* Bug Fixes
  * Fixed error when entering decimal par values.
  * Version display now shows the actual release.
  * Resolved pool calculation edge cases near 100%.
  * Corrected parsing issues that could produce NaN in founder shares.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->