### PR TITLE
docs: Add update instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ captan --help
 
 > Requires Node.js 20+
 
+### Updating
+
+If you have captan installed globally:
+```bash
+# Check current version
+captan --version
+
+# Update to latest version
+npm install -g captan@latest
+
+# Verify update
+captan --version
+```
+
+If you're using npx, it always fetches the latest by default:
+```bash
+npx captan@latest --version
+```
+
+> 💡 **Note**: `npm update -g captan` doesn't work for global packages. You must use `npm install -g captan@latest` to update.
+
 ### One-minute flow
 
 ```bash


### PR DESCRIPTION
## Summary
Adds clear instructions for updating captan to the latest version.

## Changes
- Added "Updating" section to README
- Explains how to update global installation with `npm install -g captan@latest`
- Clarifies that `npm update` doesn't work for global packages
- Shows verification steps for checking version
- Notes that npx always uses latest version

## Why This Matters
Users were confused about how to update captan (as seen when trying `npm update captan` which doesn't work for global packages). This documentation makes the update process clear.